### PR TITLE
Add subgroups to allow sorting within a group

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ formatter
 
 ### Sort all Use Statements
 
-You can sort your Use Statements in a very different ways. For this command you
+You can sort your Use Statements in different ways. For this command you
 must provide as an argument the path where to look for the PHP files you want to
 process.
 
@@ -164,12 +164,12 @@ $ php-formatter formatter:use:sort src/ --dry-run
 
 #### Group
 
-You can sort your Use statements using as many groups as yo want (***--group***).
+You can sort your Use statements using as many groups as you want (***--group***).
 It means that you can group lines with same root (***Symfony\\***) in a specific
 order.
 
 Common group is named `_main` and if is not specified, is placed in the
-begining. You can define where to place this group with `--group` option
+beginning. You can define where to place this group with the `--group` option
 
 ``` bash
 $ php-formatter formatter:use:sort src/ --group="Mmoreram" --group="_main" --group="Symfony"
@@ -191,6 +191,18 @@ use Symfony\AnotherClass;
 As you can see, a blank line is placed between groups. If any group is defined,
 one big group is created with all namespaces.
 
+When using a `.formatter.yml` you can also specify subgroups by entering an array
+
+``` yml
+use-sort:
+    group:
+        - [Symfony\Component\HttpKernel, Symfony]
+        - _main
+```
+
+This will create a Symfony group placing all `Symfony\Component\HttpKernel` classes on top.
+
+
 Finally, the `--group-type` defines if you want one `use` literal in every
 namespace line
 
@@ -210,7 +222,7 @@ use Mmoreram\MyClass;
 use Mmoreram\MySecondClass;
 ```
 
-or if you want only one use for all group.
+or if you want only one use for all groups.
 
 ``` bash
 $ php-formatter formatter:use:sort src/ --group="Mmoreram" --group-type="one"
@@ -302,7 +314,7 @@ use AnotherBundle\AnotherClass;
 
 ### Fix all PHP headers
 
-You can define your PHP header in your `.formatter.yml` file an this command
+You can define your PHP header in your `.formatter.yml` file and this command
 will check and fix that all PHP files have it properly.
 
 * command: `php-formatter formatter:header:fix`
@@ -311,7 +323,7 @@ will check and fix that all PHP files have it properly.
 
 #### Dry run
 
-You can use this tool just to test the files will be modified, using option
+You can use this tool just to test the files will be modified, using the option
 --dry-run
 
 ``` bash

--- a/src/PHPFormatter/Sorter/UseSorter.php
+++ b/src/PHPFormatter/Sorter/UseSorter.php
@@ -235,6 +235,17 @@ class UseSorter implements SorterInterface
                 continue;
             }
 
+            if (is_int($groupKey)) {
+                $subGroupSorted = array();
+                foreach ($group as $subGroupKey => $subGroup) {
+                    $subGroupSorted = array_merge($subGroupSorted, $this->sortGroup($subGroup));
+                }
+
+                $groups[$groupKey] = $subGroupSorted;
+            } else {
+                $groups[$groupKey] = $this->sortGroup($group);
+            }
+
             $groups[$groupKey] = $this->sortGroup($group);
         }
 

--- a/src/PHPFormatter/Sorter/UseSorter.php
+++ b/src/PHPFormatter/Sorter/UseSorter.php
@@ -245,8 +245,6 @@ class UseSorter implements SorterInterface
             } else {
                 $groups[$groupKey] = $this->sortGroup($group);
             }
-
-            $groups[$groupKey] = $this->sortGroup($group);
         }
 
         $doubleEOL = PHP_EOL . PHP_EOL;

--- a/src/PHPFormatter/Sorter/UseSorter.php
+++ b/src/PHPFormatter/Sorter/UseSorter.php
@@ -258,7 +258,15 @@ class UseSorter implements SorterInterface
      */
     private function createGroups(array $namespaces)
     {
-        $groups = array_fill_keys($this->groups, array());
+        $groups = array();
+
+        foreach ($this->groups as $group) {
+            if (is_array($group)) {
+                $groups[] = array_fill_keys($group, array());
+            } else {
+                $groups[$group] = array();
+            }
+        }
 
         if (!array_key_exists('_main', $groups)) {
 
@@ -272,8 +280,15 @@ class UseSorter implements SorterInterface
 
             foreach ($groups as $groupKey => $group) {
 
-                if (strpos($namespace, $groupKey) === 0) {
+                if (is_int($groupKey)) {
+                    foreach ($group as $subGroupKey => $subGroup) {
+                        if (strpos($namespace, $subGroupKey) === 0) {
+                            array_push($groups[$groupKey][$subGroupKey], $namespace);
 
+                            continue 3;
+                        }
+                    }
+                } elseif (is_string($groupKey) && strpos($namespace, $groupKey) === 0) {
                     array_push($groups[$groupKey], $namespace);
 
                     continue 2;
@@ -295,6 +310,10 @@ class UseSorter implements SorterInterface
      */
     private function sortGroup(array $group)
     {
+        if (empty($group)) {
+            return array();
+        }
+
         if ($this->sortType == self::SORT_TYPE_LENGTH) {
 
             usort($group, function ($a, $b) {

--- a/tests/PHPFormatter/Sorter/UseSorterTest.php
+++ b/tests/PHPFormatter/Sorter/UseSorterTest.php
@@ -294,7 +294,75 @@ use Test4\\Myclass3;
 use Test3\\File;
 use Test3\\MyFolder\\Myclass;
 "
+            ),
+            array(
+                ['Test2', 'TestEmpty', '_main', 'Test3'],
+                UseSorter::SORT_TYPE_ALPHABETIC,
+                UseSorter::SORT_DIRECTION_ASC,
+                UseSorter::GROUP_TYPE_EACH,
+"
+use Test2\\Myclass3;
+use Test2\\Myclass4;
+
+
+
+use Test1\\Myclass1;
+use Test1\\Myclass2;
+use Test1\\MyFolder5\\File as MyFile;
+use Test4\\Myclass3;
+
+use Test3\\File;
+use Test3\\MyFolder\\Myclass;
+"
             )
+        );
+    }
+
+    /**
+     * Test skip empty
+     */
+    public function testGroupSkip()
+    {
+        $parsedData = $this
+            ->useSorter
+            ->setGroups(['Test2', 'TestEmpty', '_main', 'Test3'])
+            ->setSortType(UseSorter::SORT_TYPE_ALPHABETIC)
+            ->setSortDirection(UseSorter::SORT_DIRECTION_ASC)
+            ->setGroupType(UseSorter::GROUP_TYPE_EACH)
+            ->setGroupSkipEmpty(true)
+            ->sort($this->data);
+
+        $result =
+"
+use Test2\\Myclass3;
+use Test2\\Myclass4;
+
+use Test1\\Myclass1;
+use Test1\\Myclass2;
+use Test1\\MyFolder5\\File as MyFile;
+use Test4\\Myclass3;
+
+use Test3\\File;
+use Test3\\MyFolder\\Myclass;
+";
+        $realResult =
+            "<?php
+
+/**
+ * Copyright
+ */
+
+namespace PHPFormatter\\Tests\\Mocks;
+$result
+/**
+ * Class SimpleMock
+ */
+class SimpleMock
+{}";
+
+        $this->assertEquals(
+            $realResult,
+            $parsedData
         );
     }
 }

--- a/tests/PHPFormatter/Sorter/UseSorterTest.php
+++ b/tests/PHPFormatter/Sorter/UseSorterTest.php
@@ -314,7 +314,25 @@ use Test4\\Myclass3;
 use Test3\\File;
 use Test3\\MyFolder\\Myclass;
 "
-            )
+            ),
+            array(
+                ['Test2', ['Test1\MyFolder5', 'Test1'], '_main'],
+                UseSorter::SORT_TYPE_ALPHABETIC,
+                UseSorter::SORT_DIRECTION_ASC,
+                UseSorter::GROUP_TYPE_EACH,
+                "
+use Test2\\Myclass3;
+use Test2\\Myclass4;
+
+use Test1\\MyFolder5\\File as MyFile;
+use Test1\\Myclass1;
+use Test1\\Myclass2;
+
+use Test3\\File;
+use Test3\\MyFolder\\Myclass;
+use Test4\\Myclass3;
+"
+            ),
         );
     }
 


### PR DESCRIPTION
Example .formatter.yml:
```yml
use-sort:
    group:
        - [Symfony\Component\HttpKernel, Symfony]
        - _main
        - App
```

to put Symfony\Component\HttpKernel classes on top of the group

Fixes #10