### PR TITLE
Add support for single files

### DIFF
--- a/src/PHPFormatter/Finder/FileFinder.php
+++ b/src/PHPFormatter/Finder/FileFinder.php
@@ -1,15 +1,16 @@
 <?php
 
 /*
- * This file is part of MITRE's ACE project
+ * This file is part of the php-formatter package
  *
- * Copyright (c) 2015 MITRE Corporation
+ * Copyright (c) 2014 Marc Morera
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
+ * Feel free to edit as you please, and have fun.
  *
- * @author MITRE's ACE Team <ace-team@mitre.org>
+ * @author Marc Morera <yuhu@mmoreram.com>
  */
 
 namespace Mmoreram\PHPFormatter\Finder;

--- a/src/PHPFormatter/Finder/FileFinder.php
+++ b/src/PHPFormatter/Finder/FileFinder.php
@@ -1,16 +1,15 @@
 <?php
 
 /*
- * This file is part of the php-formatter package
+ * This file is part of MITRE's ACE project
  *
- * Copyright (c) 2014 Marc Morera
+ * Copyright (c) 2015 MITRE Corporation
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * Feel free to edit as you please, and have fun.
  *
- * @author Marc Morera <yuhu@mmoreram.com>
+ * @author MITRE's ACE Team <ace-team@mitre.org>
  */
 
 namespace Mmoreram\PHPFormatter\Finder;
@@ -32,11 +31,16 @@ class FileFinder
     public function findPHPFilesByPath($path)
     {
         $finder = new Finder();
-        $finder
-            ->files()
-            ->in($path)
-            ->name('*.php');
-
+        
+        if (file_exists($path) && !is_dir($path)) {
+            $finder->append([0 => $path]);
+        } else {
+            $finder
+                ->files()
+                ->in($path)
+                ->name('*.php');
+        }
+        
         return $finder;
     }
 }


### PR DESCRIPTION
There may be a time when the user would like to pass just a single file to the formatter instead of an entire directory.