### PR TITLE
Build against PHP 7.2 with lowest dependencies

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,18 +1,20 @@
 <?php
 
-return Symfony\CS\Config\Config::create()
-    // use SYMFONY_LEVEL:
-    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
-    // and extra fixers:
-    ->fixers(array(
-        'concat_with_spaces',
-        'multiline_spaces_before_semicolon',
-        'short_array_syntax',
-        '-remove_lines_between_uses'
-    ))
-    ->finder(
-        Symfony\CS\Finder\DefaultFinder::create()
-            ->in('src/')
-            ->in('tests/')
-    )
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'no_multiline_whitespace_before_semicolons' => false,
+        'array_syntax' => ['syntax' => 'short'],
+        'yoda_style' => false,
+        'return_type_declaration' => ['space_before' => 'one'],
+        'self_accessor' => false,
+        'no_extra_consecutive_blank_lines' => false,
+    ])
+    ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,20 @@ language: php
 
 sudo: false
 
-php:
-    - 7.0
-    - 7.1
+matrix:
+    include:
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+          env: deps=low
+    fast_finish: true
 
 install:
-    - composer update --prefer-source --no-interaction
+    - phpenv config-rm xdebug.ini
+    - if [[ $deps = low ]]; then composer update --prefer-lowest --prefer-stable; else composer install; fi
 
 script:
-    - vendor/bin/phpunit --coverage-text
+    - phpdbg -qrr vendor/bin/phpunit --coverage-text
 
 notifications:
     email: false

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ need the [box-project/box2](https://github.com/box-project/box2) library.
 ``` bash
 $ git clone git@github.com:mmoreram/php-formatter.git
 $ cd php-formatter
-$ composer update
+$ composer update --no-dev
 $ box build -v
 $ build/php-formatter.phar
 ```

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/property-access": "^3.2"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^1.12.4",
+        "friendsofphp/php-cs-fixer": "^2.8.3",
         "phpunit/phpunit": "^5.6.4"
     },
     "bin": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,4 +21,10 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
To make this possible I had to upgrade php-cs-fixer to v2. 

By building against lowest dependencies we can prove that code indeed works with them (otherwise we're only testing against latest versions). A good thing to do here is to take the latest PHP version with lowest dependencies. This way the most critical path is covered without having to run all the combinations.

I also took the courtesy to disable XDebug so composer is more happy (faster). Coverage can be easily generated with [php-dbg](http://php.net/manual/en/debugger-about.php). I also added a filter to `phpunit.xml.dist` so the coverage is actually generated (it hasn't been before).