### PR TITLE
Fix building a phar

### DIFF
--- a/box.json
+++ b/box.json
@@ -23,8 +23,7 @@
             ],
             "in": [
                 "vendor/symfony",
-                "vendor/composer",
-                "vendor/paragonie"
+                "vendor/composer"
             ],
             "name": "*.php"
         }


### PR DESCRIPTION
`box build` should be run with no dev dependencies. 

To reproduce the issue run:

```
composer install --no-dev
box build
```

box will throw the following exception:

```
  [InvalidArgumentException]
  The "/root/php-formatter/vendor/paragonie" directory does not exist.
```

paragonie vendor is not present when dev dependencies are not installed. 